### PR TITLE
fixed NullPointerException for arraycolls with null elements

### DIFF
--- a/jdeserialize/src/arraycoll.java
+++ b/jdeserialize/src/arraycoll.java
@@ -42,7 +42,7 @@ public class arraycoll extends ArrayList<Object> {
             } else {
                 sb.append(", ");
             }
-            sb.append(o.toString());
+            sb.append(o == null ? "null" : o.toString());
         }
         return sb.toString();
     }


### PR DESCRIPTION
If an `arraycoll` had a `null` element, the software crashed like below

```
Exception in thread "main" java.lang.NullPointerException
        at org.unsynchronized.arraycoll.toString(arraycoll.java:45)
        at org.unsynchronized.arrayobj.toString(arrayobj.java:31)
        at org.unsynchronized.jdeserialize.dump_Instance(jdeserialize.java:329)
        at org.unsynchronized.jdeserialize.dump(jdeserialize.java:961)
        at org.unsynchronized.jdeserialize.main(jdeserialize.java:1187)
```

This pull request fixes this, the string `null` is printed instead of calling `.toString()` on (and thus dereferencing) `null` object references.
